### PR TITLE
🔧 Fix 1 policy violations in nginx-demo

### DIFF
--- a/manifests/nginx/nginx.yaml
+++ b/manifests/nginx/nginx.yaml
@@ -1,22 +1,39 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx
+  annotations:
+    argocd.argoproj.io/tracking-id: nginx-demo:apps/Deployment:nginx-demo/nginx
   labels:
     app: nginx
     test: test
+  name: nginx
+  namespace: nginx-demo
 spec:
+  progressDeadlineSeconds: 600
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: nginx
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
   template:
     metadata:
       labels:
         app: nginx
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.14.2
+      - image: nginx:1.14.2
+        imagePullPolicy: IfNotPresent
+        name: nginx
         securityContext:
-          privileged: true
+          privileged: false
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## 🤖 Automated Policy Violation Remediation

This pull request fixes **1 policy violations** in the `nginx-demo` application.

### 📋 Violations Fixed

- **disallow-privileged-containers** in `Deployment/nginx`: validation error: Privileged mode is disallowed. rule autogen-privileged-containers failed at path /spec/template/spec/containers/0/securityContext/privileged/

### 🔍 Validation

✅ AI-generated remediation
✅ nctl policy validation passed
✅ Ready for review and merge

### 🚀 Generated by

Nirmata Remediator Agent - Automated GitOps Policy Remediation
